### PR TITLE
add Content parser

### DIFF
--- a/config/zeus-sky.php
+++ b/config/zeus-sky.php
@@ -133,4 +133,14 @@ return [
      * \LaraZeus\Sky\Classes\MarkdownEditor::class,
      */
     'editor' => \LaraZeus\Sky\Classes\TinyEditor::class,
+
+    /**
+     * parse the content
+     * you can add any parser to do str_replace or any other operation:
+     *
+     * to render Blot form by it slug: \LaraZeus\Sky\Classes\BoltParser::class,
+     */
+    'parsers' => [
+        \LaraZeus\Sky\Classes\BoltParser::class,
+    ],
 ];

--- a/src/Classes/BoltParser.php
+++ b/src/Classes/BoltParser.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LaraZeus\Sky\Classes;
+
+use Illuminate\Support\Facades\Blade;
+
+class BoltParser
+{
+    public function __invoke(string $content): string
+    {
+        if (class_exists(\LaraZeus\Bolt\Facades\Bolt::class)) {
+            $content = html_entity_decode($content);
+            preg_match('/<bolt>(.*?)<\/bolt>/s', $content, $bolt);
+            if (is_array($bolt) && isset($bolt[1])) {
+                $formSlug = trim($bolt[1]);
+                $checkForm = config('zeus-bolt.models.Form')::where('slug', $formSlug)->first();
+                if ($checkForm !== null) {
+                    $boltComponent = Blade::render('<livewire:bolt.fill-form slug="' . $formSlug . '" />');
+                    $content = str_replace('<bolt>' . $formSlug . '</bolt>', $boltComponent, $content);
+                }
+            }
+        }
+
+        return $content;
+    }
+}

--- a/src/Classes/TipTapEditor.php
+++ b/src/Classes/TipTapEditor.php
@@ -4,17 +4,13 @@ namespace LaraZeus\Sky\Classes;
 
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Textarea;
-use FilamentTiptapEditor\Exceptions\InvalidOutputFormatException;
 use FilamentTiptapEditor\TiptapEditor as TipTapEditorAlias;
 
 class TipTapEditor implements ContentEditor
 {
-    /**
-     * @throws InvalidOutputFormatException
-     */
     public static function component(): Component
     {
-        if (class_exists(TipTapEditorAlias::class, false)) {
+        if (class_exists(TipTapEditorAlias::class)) {
             return \FilamentTiptapEditor\TiptapEditor::make('content')
                 ->profile('default')
                 ->output(\FilamentTiptapEditor\TiptapEditor::OUTPUT_HTML)
@@ -26,7 +22,8 @@ class TipTapEditor implements ContentEditor
 
     public static function render(string $content): string
     {
-        if (class_exists(TipTapEditorAlias::class, false)) {
+        if (class_exists(TipTapEditorAlias::class)) {
+            // @phpstan-ignore-next-line
             return tiptap_converter()->asHTML($content);
             // return tiptap_converter()->asJSON($content);
             // return tiptap_converter()->asText($content);

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -106,6 +106,19 @@ class Post extends Model implements HasMedia
 
     public function getContent(): string
     {
-        return config('zeus-sky.editor')::render($this->content);
+        return $this->parseContent(config('zeus-sky.editor')::render($this->content));
+    }
+
+    public function parseContent($content): string
+    {
+        $parsers = config('zeus-sky.parsers');
+
+        if (! empty($parsers)) {
+            foreach ($parsers as $parser) {
+                $content = (new $parser)($content);
+            }
+        }
+
+        return $content;
     }
 }


### PR DESCRIPTION
adding the ability to parse the content
available by default: `BoltParser`, lets you include or (embed) bolt form into any page with the syntax: `<bolt>formSlug</bolt>`

This will be parsed to a livewire component to display the full form.

## How to use:
make sure to add this to your config:

```php
'parsers' => [
    \LaraZeus\Sky\Classes\BoltParser::class,
],
```

and you can copy that class and create your own parser, too, then add it to the array, sky will loop them all.

still under testing.

