### PR TITLE
use proper package for ryangjchandler/filament-navigation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "filament/spatie-laravel-translatable-plugin": "^2.0",
     "lara-zeus/core": "^2.4",
     "mohamedsabil83/filament-forms-tinyeditor": "^1.7",
-    "ryangjchandler/filament-navigation": "dev-with-rtl",
+    "ryangjchandler/filament-navigation": "^0.5.0",
     "spatie/laravel-medialibrary": "^10.0.0",
     "spatie/laravel-sluggable": "^3.3",
     "spatie/laravel-tags": "^4.4"


### PR DESCRIPTION
fixes:

```
╰─λ sail composer update -W                                                              0 (0.013s)
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires lara-zeus/sky ^2.4.33 -> satisfiable by lara-zeus/sky[2.4.33].
    - lara-zeus/sky 2.4.33 requires ryangjchandler/filament-navigation dev-with-rtl -> found ryangj
chandler/filament-navigation[dev-dependabot/github_actions/dependabot/fetch-metadata-1.6.0, dev-dep
endabot/github_actions/ramsey/composer-install-2, dev-main, v0.1.0, ..., v0.5.0] but it does not ma
tch the constraint.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages
 currently locked to specific versions.
```