### PR TITLE
fix: evaluate potential closure value before rendering component

### DIFF
--- a/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
+++ b/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php
@@ -112,10 +112,10 @@ trait HandlesNavigationBuilder
                     Group::make()
                         ->statePath('data')
                         ->whenTruthy('type')
-                        ->schema(function (Get $get) {
+                        ->schema(function (Get $get, Component $component) {
                             $type = $get('type');
 
-                            return SkyPlugin::get()->getItemTypes()[$type]['fields'] ?? [];
+                            return $component->evaluate(SkyPlugin::get()->getItemTypes()[$type]['fields']) ?? [];
                         }),
                     Group::make()
                         ->statePath('data')


### PR DESCRIPTION
Fixes #196 

The changes were made in this way to match the style of how `getExtraFields()` is handled. Essentially matching style parity with:  
https://github.com/lara-zeus/sky/blob/6efe70211d2cdf0bea49e13847bcede47aadbde5/src/Filament/Resources/NavigationResource/Pages/Concerns/HandlesNavigationBuilder.php#L122