### PR TITLE
fix: use heroicons instead of tabler

### DIFF
--- a/resources/views/themes/zeus/sky/partial/empty.blade.php
+++ b/resources/views/themes/zeus/sky/partial/empty.blade.php
@@ -1,4 +1,4 @@
 <div class="px-4 py-4 bg-gradient-to-br from-white via-white to-primary-50 shadow-lg rounded-3xl hover:shadow-xl transition ease-in-out duration-300 flex gap-2 items-center justify-center w-full h-72 border border-gray-100">
-    @svg('tabler-wave-sine','h-10 w-10 text-primary-600')
+    @svg('heroicon-s-newspaper','h-10 w-10 text-primary-600')
     <span class="underline decoration-wavy underline-offset-4 decoration-primary-600">{{ __('No posts found') }}!</span>
 </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a2f9a60d-5bb1-4416-9bd2-7c54e8b7434e)


tabler icons are not required with sky package, so I used newspaper icon from heroicons