### PR TITLE
Honor FAQ and library resource switches

### DIFF
--- a/src/SkyPlugin.php
+++ b/src/SkyPlugin.php
@@ -49,11 +49,11 @@ final class SkyPlugin implements Plugin
             $panel->resources([PageResource::class]);
         }
 
-        if (! in_array(FaqResource::class, $this->getHiddenResources())) {
+        if ($this->hasFaqResource() && ! in_array(FaqResource::class, $this->getHiddenResources())) {
             $panel->resources([FaqResource::class]);
         }
 
-        if (! in_array(LibraryResource::class, $this->getHiddenResources())) {
+        if ($this->hasLibraryResource() && ! in_array(LibraryResource::class, $this->getHiddenResources())) {
             $panel->resources([LibraryResource::class]);
         }
 

--- a/tests/SkyPluginTest.php
+++ b/tests/SkyPluginTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Filament\Panel;
+use LaraZeus\Sky\Filament\Resources\FaqResource;
+use LaraZeus\Sky\Filament\Resources\LibraryResource;
+use LaraZeus\Sky\SkyPlugin;
+
+it('registers the addon resources by default', function () {
+    $panel = Panel::make();
+
+    SkyPlugin::make()->register($panel);
+
+    expect($panel->getResources())
+        ->toContain(FaqResource::class)
+        ->toContain(LibraryResource::class);
+});
+
+it('does not register a disabled addon resource', function (string $method, string $disabledResource, string $enabledResource) {
+    $panel = Panel::make();
+
+    $plugin = SkyPlugin::make();
+    $plugin->{$method}(false);
+    $plugin->register($panel);
+
+    expect($panel->getResources())->not->toContain($disabledResource);
+    expect($panel->getResources())->toContain($enabledResource);
+})->with([
+    'FAQ' => ['faqResource', FaqResource::class, LibraryResource::class],
+    'library' => ['libraryResource', LibraryResource::class, FaqResource::class],
+]);


### PR DESCRIPTION
## Summary
- honor the existing FAQ and Library resource switches during panel registration
- keep each addon independent when the other is disabled
- cover default and disabled registration with focused Pest tests

## Verification
- composer test:pest
- vendor/bin/pint --test
- vendor/bin/phpstan analyse src/SkyPlugin.php --no-progress --debug --memory-limit=1G
- git diff --check

Fixes #269